### PR TITLE
Missing GitBlit-support after updating to 2.x #41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,3 +72,8 @@ All Notable changes to `Open in Git host` will be documented in this file
 ## 2.1.2 - 2017-11-15
 
 - Fixed issue preventing port numbers with more than 4 digits being removed #52.
+
+
+## 2.2.0 - 2017-11-10
+
+- Added support for GitBlit. #41

--- a/build.gradle
+++ b/build.gradle
@@ -42,4 +42,4 @@ intellij {
 }
 
 group 'org.jetbrains'
-version '2.1.2'
+version '2.2.0'

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,14 +1,14 @@
 <idea-plugin url="https://github.com/ben-gibson/GitLink">
     <id>uk.co.ben-gibson.remote.repository.mapper</id>
     <name>GitLink</name>
-    <version>2.1.2</version>
+    <version>2.2.0</version>
     <vendor url="https://github.com/ben-gibson/GitLink">Ben Gibson</vendor>
     <description><![CDATA[
-      Provides shortcuts to open a file or commit in Stash, GitHub, BitBucket or GitLab using the default browser or copy the link to the clipboard.
+      Provides shortcuts to open a file or commit in Stash, GitHub, BitBucket, GitLab or GitBlit using the default browser or copy the link to the clipboard.
       <br />
       <br />
       After installing select your remote host in Settings &rarr; Other Settings &rarr; GitLink
-      (currently supports GitHub, Stash, BitBucket and GitLab). Make sure you have registered your project's root under the version control settings.
+      (currently supports GitHub, Stash, BitBucket, GitLab and GitBlit). Make sure you have registered your project's root under the version control settings.
       Preferences → Version Control (see unregistered roots)
       <br />
       <br />
@@ -23,7 +23,7 @@
     ]]></description>
     <change-notes><![CDATA[
     <ul>
-      <li>Fixed issue preventing port numbers with more than 4 digits being removed <a href="https://github.com/ben-gibson/GitLink/issues/52">#52</a>.</li>
+      <li>Added support for GitBlit. <a href="https://github.com/ben-gibson/GitLink/issues/41">#41</a></li>
      </ul>
     ]]>
     </change-notes>

--- a/src/uk/co/ben_gibson/git/link/Container.java
+++ b/src/uk/co/ben_gibson/git/link/Container.java
@@ -70,6 +70,7 @@ public class Container
             UrlFactoryProvider provider = new UrlFactoryProvider();
 
             provider.registerFactory(new GitHubUrlFactory());
+            provider.registerFactory(new GitBlitUrlFactory());
             provider.registerFactory(new BitBucketUrlFactory());
             provider.registerFactory(new StashUrlFactory());
             provider.registerFactory(

--- a/src/uk/co/ben_gibson/git/link/Git/RemoteHost.java
+++ b/src/uk/co/ben_gibson/git/link/Git/RemoteHost.java
@@ -12,6 +12,7 @@ public enum RemoteHost
     STASH("Stash", "/Icons/Bitbucket/Bitbucket.png"),
     BITBUCKET("Bitbucket", "/Icons/Bitbucket/Bitbucket.png"),
     GITLAB("GitLab", "/Icons/GitLab/GitLab.png"),
+    GITBLIT("GitBlit", ""),
     CUSTOM("Custom", "/Icons/Custom/Custom.png");
 
     private final String name;
@@ -31,6 +32,11 @@ public enum RemoteHost
     public boolean custom()
     {
         return (this == CUSTOM);
+    }
+
+    public boolean gitBlit()
+    {
+        return (this == GITBLIT);
     }
 
     public boolean gitHub()

--- a/src/uk/co/ben_gibson/git/link/Url/Factory/GitBlitUrlFactory.java
+++ b/src/uk/co/ben_gibson/git/link/Url/Factory/GitBlitUrlFactory.java
@@ -1,0 +1,136 @@
+package uk.co.ben_gibson.git.link.Url.Factory;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jetbrains.annotations.NotNull;
+import uk.co.ben_gibson.git.link.Git.Exception.RemoteException;
+import uk.co.ben_gibson.git.link.Git.Remote;
+import uk.co.ben_gibson.git.link.Git.RemoteHost;
+import uk.co.ben_gibson.git.link.Url.Factory.Description.CommitDescription;
+import uk.co.ben_gibson.git.link.Url.Factory.Description.FileDescription;
+import uk.co.ben_gibson.git.link.Url.Factory.Exception.UrlFactoryException;
+
+public class GitBlitUrlFactory extends AbstractUrlFactory {
+    @Override
+    public URL createUrl(CommitDescription description) throws RemoteException, UrlFactoryException {
+        Remote remote = description.remote();
+
+        String remoteUrl = description.remote().url().getPath();
+
+        Map<String, String> patterns = new LinkedHashMap<>();
+
+        patterns.put("(?<context>/.+?)?/(git/r)/(?<repo>.+)", "<context>/git/commitdiff/<repo>.git/<revision>");
+        patterns.put("(?<context>/.+?)?/(git|r)/(?<repo>.+)", "<context>/commitdiff/<repo>.git/<revision>");
+
+        for (Map.Entry<String, String> urlPattern : patterns.entrySet()) {
+            String pattern = urlPattern.getKey();
+            String url = urlPattern.getValue();
+
+            Matcher matcher = Pattern.compile(pattern).matcher(remoteUrl);
+            if (matcher.matches()) {
+
+                // Get the placeholder values for the URL
+                Map<String, String> placeholders = new HashMap<>();
+                placeholders.put("<context>", getContext(matcher));
+                placeholders.put("<repo>", this.replaceSlashWithBang(this.getGroupFromMatcher(matcher, "repo")));
+                placeholders.put("<revision>", description.commitHash());
+
+                // Replace the URL placeholders
+                for (Map.Entry<String, String> placeHolder : placeholders.entrySet()) {
+                    url = url.replaceAll(placeHolder.getKey(), placeHolder.getValue());
+                }
+
+                return this.buildURL(remote, url, null, null);
+            }
+        }
+
+        throw UrlFactoryException.cannotCreateUrl(String.format("Repository URL %s is not supported", remoteUrl));
+    }
+
+    @Override
+    public URL createUrl(FileDescription description) throws RemoteException, UrlFactoryException {
+        Remote remote = description.remote();
+
+        String remoteUrl = description.remote().url().getPath();
+
+        Map<String, String> patterns = new LinkedHashMap<>();
+
+        patterns.put("(?<context>/.+?)?/(git/r)/(?<repo>.+)", "<context>/git/blob/<repo>.git/<branch>/<fullfilepath>");
+        patterns.put("(?<context>/.+?)?/(git|r)/(?<repo>.+)", "<context>/blob/<repo>.git/<branch>/<fullfilepath>");
+
+        for (Map.Entry<String, String> urlPattern : patterns.entrySet()) {
+
+            String pattern = urlPattern.getKey();
+            String url = urlPattern.getValue();
+
+            Matcher matcher = Pattern.compile(pattern).matcher(remoteUrl);
+
+            if (matcher.matches()) {
+
+                // Get the placeholder values for the URL
+                Map<String, String> placeholders = new HashMap<>();
+                placeholders.put("<context>", getContext(matcher));
+                placeholders.put("<repo>", this.replaceSlashWithBang(this.getGroupFromMatcher(matcher, "repo")));
+                placeholders.put("<branch>", this.replaceSlashWithBang(description.branch().toString()));
+                placeholders.put("<fullfilepath>", this.replaceSlashWithBang(description.file().pathWithName()));
+
+                // Replace the URL placeholders
+                for (Map.Entry<String, String> placeHolder : placeholders.entrySet()) {
+                    url = url.replaceAll(placeHolder.getKey(), placeHolder.getValue());
+                }
+
+                String fragment = null;
+                if (description.hasLineNumber()) {
+                    fragment = String.format("L%d", description.lineNumber());
+                }
+
+                return this.buildURL(remote, url, null, fragment);
+            }
+        }
+
+        throw UrlFactoryException.cannotCreateUrl(String.format("Repository URL %s is not supported", remoteUrl));
+    }
+
+    @Override
+    public boolean supports(RemoteHost host) {
+        return host.gitBlit();
+    }
+
+    private String getContext(Matcher matcher) {
+        String context = this.getGroupFromMatcher(matcher, "context");
+        if (context != null) {
+            return context;
+        }
+        return "";
+    }
+
+    /**
+     * Get a selected group from a matcher.
+     *
+     * @param matcher The matcher to get a group from.
+     * @param name    The group to get from the matcher.
+     * @return String
+     */
+    private String getGroupFromMatcher(Matcher matcher, String name) {
+        try {
+            return matcher.group(name);
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            return "";
+        }
+    }
+
+    /**
+     * Replace forward slash character with bang.
+     *
+     * @param string The string to replace forward slash characters.
+     * @return String
+     */
+    @NotNull
+    private String replaceSlashWithBang(@NotNull String string) {
+        return string.replaceAll("/", "!");
+    }
+}

--- a/tests/unit/uk/co/ben_gibson/git/link/test/Url/Factory/GitBlitUrlFactoryTest.java
+++ b/tests/unit/uk/co/ben_gibson/git/link/test/Url/Factory/GitBlitUrlFactoryTest.java
@@ -1,0 +1,104 @@
+package uk.co.ben_gibson.git.link.test.Url.Factory;
+
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import uk.co.ben_gibson.git.link.Git.Branch;
+import uk.co.ben_gibson.git.link.Git.Exception.RemoteException;
+import uk.co.ben_gibson.git.link.Url.Factory.Description.CommitDescription;
+import uk.co.ben_gibson.git.link.Url.Factory.Description.FileDescription;
+import uk.co.ben_gibson.git.link.Url.Factory.GitBlitUrlFactory;
+import uk.co.ben_gibson.git.link.Url.Factory.UrlFactory;
+
+import java.net.MalformedURLException;
+
+public class GitBlitUrlFactoryTest extends UrlFactoryTest
+{
+
+    @DataProvider
+    public static Object[][] commitProvider() throws MalformedURLException, RemoteException
+    {
+        return new Object[][]{
+                {
+                        new CommitDescription(
+                                mockRemote("http://my.company.com/gitblit/git/category/my.complex.repo"),
+                                UrlFactoryTest.mockCommit("1234")
+                        ),
+                        "http://my.company.com/gitblit/commitdiff/category!my.complex.repo.git/1234"
+                },
+                {
+                        new CommitDescription(
+                                mockRemote("http://my.company.com/git/r/patts-qt"),
+                                UrlFactoryTest.mockCommit("1234")
+                        ),
+                        "http://my.company.com/git/commitdiff/patts-qt.git/1234"
+                },
+                {
+                        new CommitDescription(
+                                mockRemote("http://my.company.com/r/patts-qt"),
+                                UrlFactoryTest.mockCommit("1234")
+                        ),
+                        "http://my.company.com/commitdiff/patts-qt.git/1234"
+                },
+                {
+                        new CommitDescription(
+                                mockRemote("http://my.company.com/git/patts-qt"),
+                                UrlFactoryTest.mockCommit("1234")
+                        ),
+                        "http://my.company.com/commitdiff/patts-qt.git/1234"
+                },
+
+        };
+    }
+
+    @DataProvider
+    public static Object[][] fileProvider() throws MalformedURLException, RemoteException
+    {
+        return new Object[][]{
+
+                {
+                        new FileDescription(
+                                mockRemote("http://my.company.com/gitblit/git/category/my.complex.repo"),
+                                new Branch("feature/feature42D"),
+                                mockFile("src/com/foo/FooTest.java", "FooTest.java"),
+                                32
+                        ),
+                        "http://my.company.com/gitblit/blob/category!my.complex.repo.git/feature!feature42D/src!com!foo!FooTest.java#L32",
+                },
+                {
+                        new FileDescription(
+                                mockRemote("http://my.company.com/git/r/ljpapi"),
+                                new Branch("feature/feature42D"),
+                                mockFile("src/com/company/ljp/Alignment.java", "Alignment.java"),
+                                32
+                        ),
+                        "http://my.company.com/git/blob/ljpapi.git/feature!feature42D/src!com!company!ljp!Alignment.java#L32"
+
+                },
+                {
+                        new FileDescription(
+                                mockRemote("http://my.company.com/r/ljpapi"),
+                                new Branch("feature/feature42D"),
+                                mockFile("src/com/company/ljp/Alignment.java", "Alignment.java"),
+                                32
+                        ),
+                        "http://my.company.com/blob/ljpapi.git/feature!feature42D/src!com!company!ljp!Alignment.java#L32"
+
+                },
+                {
+                        new FileDescription(
+                                mockRemote("http://my.company.com/git/ljpapi"),
+                                new Branch("feature/feature42D"),
+                                mockFile("src/com/company/ljp/Alignment.java", "Alignment.java"),
+                                32
+                        ),
+                        "http://my.company.com/blob/ljpapi.git/feature!feature42D/src!com!company!ljp!Alignment.java#L32"
+
+                },
+
+        };
+    }
+
+    public UrlFactory remoteUrlFactory()
+    {
+        return new GitBlitUrlFactory();
+    }
+}


### PR DESCRIPTION
* note that GitBlit has no offical favicon, so I couldn't add one

@ben-gibson: Please review and integrate!