### PR TITLE
Regression in 2.3.0: Opening a commit from the VCS log fails.

### DIFF
--- a/src/uk/co/ben_gibson/git/link/UI/Action/Vcs/VcsLogAction.java
+++ b/src/uk/co/ben_gibson/git/link/UI/Action/Vcs/VcsLogAction.java
@@ -29,7 +29,7 @@ abstract class VcsLogAction extends Action
         }
 
         VcsFullCommitDetails vcsCommit = vcsLog.getSelectedDetails().get(0);
-        Commit commit = new Commit(vcsCommit.toString());
+        Commit commit = new Commit(vcsCommit.getId().toShortString());
 
         this.getManager().handleCommit(this.urlHandler(), project, commit, vcsCommit.getRoot());
     }


### PR DESCRIPTION
Use a proper way to get the revision number.