### PR TITLE
Fix 2021.2 error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,15 @@
 plugins {
-    id 'org.jetbrains.intellij' version '0.7.2'
+    id 'org.jetbrains.intellij' version '1.1.4'
 }
 
 group 'uk.co.ben-gibson'
-version '3.3.4'
+version '3.3.5'
 
 ext {
     if (!project.hasProperty("intellijPublishToken")) {
         ext.intellijPublishToken = "foo"
     }
 }
-
-apply plugin: 'idea'
-apply plugin: 'org.jetbrains.intellij'
-apply plugin: 'java'
 
 sourceCompatibility = 11
 targetCompatibility = 11
@@ -30,17 +26,14 @@ dependencies {
 }
 
 intellij {
-    version ideaVersion
-    plugins 'git4idea'
-    pluginName 'GitLink'
+    version = '2021.2'
+    plugins = ['git4idea']
+    pluginName = 'GitLink'
     updateSinceUntilBuild = true
 }
 
 patchPluginXml {
-    sinceBuild pluginSinceBuild
-    untilBuild pluginUntilBuild
-    version version
-    pluginDescription """
+    pluginDescription = """
 Provides a shortcut to open a file or commit in GitHub, Bitbucket, GitLab, Gitea, Gogs or GitBlit using the default 
 browser. A Shortcut is also available to copy links to your clipboard. <br>
 <br>
@@ -51,15 +44,15 @@ Preferences → Version Control (see unregistered roots) <br>
 To open a file in the default browser select View &rarr; Open in (your selected host). Shortcuts are also available on
 the annotation gutter and VCS log window.
     """
-    changeNotes """
-<p>3.3.4</p>
+    changeNotes = """
+<p>3.3.5</p>
 <ul>
-    <li>Fixed errors in latest 2021 EAP</li>
+    <li>Fixed errors in latest 2021.2</li>
 </ul>
     """
 
 }
 
 publishPlugin {
-    token intellijPublishToken
+    token = intellijPublishToken
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
i updated the intellij plugin to the latest and the bug disappeared.

i'm new to IDEA plugins, so i was not sure on some stuff i removed how to setup with the new syntax. 

i was testing this one and its working

I'm not sure what is jetbrains plan, do they actually want us to do a update on each major IDE update? but this is what other plugins did this week after update 2021.2 marked them incompatible.

this is the build i did
[GitLink-3.3.5.zip](https://github.com/ben-gibson/GitLink/files/6920427/GitLink-3.3.5.zip)

Fixes #146
Fixes #143