### PR TITLE
refactor: get rid of  ServiceManager.getService() deprecation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ intellij {
     version = '2021.2'
     plugins = ['git4idea']
     pluginName = 'GitLink'
-    updateSinceUntilBuild = true
+    updateSinceUntilBuild = false
 }
 
 patchPluginXml {

--- a/src/main/java/uk/co/ben_gibson/git/link/Git/RepositoryLocator.java
+++ b/src/main/java/uk/co/ben_gibson/git/link/Git/RepositoryLocator.java
@@ -1,6 +1,5 @@
 package uk.co.ben_gibson.git.link.Git;
 
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vcs.LocalFilePath;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -19,7 +18,7 @@ public class RepositoryLocator
     }
 
     public static RepositoryLocator getInstance(Project project) {
-        return ServiceManager.getService(project, RepositoryLocator.class);
+        return project.getService(RepositoryLocator.class);
     }
 
     @NotNull

--- a/src/main/java/uk/co/ben_gibson/git/link/GitLink.java
+++ b/src/main/java/uk/co/ben_gibson/git/link/GitLink.java
@@ -1,6 +1,6 @@
 package uk.co.ben_gibson.git.link;
 
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
@@ -23,7 +23,7 @@ import java.net.URL;
 
 public class GitLink
 {
-    private Logger logger = Logger.getInstance(ServiceManager.getService(Plugin.class).displayName());
+    private Logger logger = Logger.getInstance(ApplicationManager.getApplication().getService(Plugin.class).displayName());
     private final RepositoryLocator repositoryLocator;
     private final ExceptionRenderer exceptionRenderer;
     private final UrlModifierProvider urlModifierProvider;
@@ -36,7 +36,7 @@ public class GitLink
     GitLink(Project project) {
         this.repositoryLocator = RepositoryLocator.getInstance(project);
         this.exceptionRenderer = ExceptionRenderer.getInstance();
-        this.urlModifierProvider = ServiceManager.getService(UrlModifierProvider.class);
+        this.urlModifierProvider = ApplicationManager.getApplication().getService(UrlModifierProvider.class);
         this.browserHandler = BrowserHandler.getInstance();
         this.clipboardHandler = ClipboardHandler.getInstance();
         this.urlFactoryLocator = UrlFactoryLocator.getInstance(project);
@@ -45,7 +45,7 @@ public class GitLink
     }
 
     public static GitLink getInstance(Project project) {
-        return ServiceManager.getService(project, GitLink.class);
+        return project.getService(GitLink.class);
     }
 
     public void openFile(@NotNull final VirtualFile file, final Commit commit, final LineSelection lineSelection) {

--- a/src/main/java/uk/co/ben_gibson/git/link/Preferences.java
+++ b/src/main/java/uk/co/ben_gibson/git/link/Preferences.java
@@ -1,6 +1,5 @@
 package uk.co.ben_gibson.git.link;
 
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 import uk.co.ben_gibson.git.link.Git.Branch;
@@ -82,7 +81,7 @@ public class Preferences implements PersistentStateComponent<Preferences>
 
     public static Preferences getInstance(Project project)
     {
-        return ServiceManager.getService(project, Preferences.class);
+        return project.getService(Preferences.class);
     }
 
 

--- a/src/main/java/uk/co/ben_gibson/git/link/UI/Action/Action.java
+++ b/src/main/java/uk/co/ben_gibson/git/link/UI/Action/Action.java
@@ -3,7 +3,7 @@ package uk.co.ben_gibson.git.link.UI.Action;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.Presentation;
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
@@ -13,7 +13,7 @@ import uk.co.ben_gibson.git.link.Preferences;
 
 public abstract class Action extends AnAction
 {
-    private final Logger logger = Logger.getInstance(ServiceManager.getService(Plugin.class).displayName());
+    private final Logger logger = Logger.getInstance(ApplicationManager.getApplication().getService(Plugin.class).displayName());
 
     protected abstract boolean shouldActionBeEnabled(@NotNull final AnActionEvent event);
 

--- a/src/main/java/uk/co/ben_gibson/git/link/UI/ExceptionRenderer.java
+++ b/src/main/java/uk/co/ben_gibson/git/link/UI/ExceptionRenderer.java
@@ -3,7 +3,7 @@ package uk.co.ben_gibson.git.link.UI;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import org.jetbrains.annotations.NotNull;
 import uk.co.ben_gibson.git.link.Exception.GitLinkException;
 import uk.co.ben_gibson.git.link.Plugin;
@@ -13,11 +13,11 @@ public class ExceptionRenderer
     private final Plugin plugin;
 
     public ExceptionRenderer() {
-        this.plugin = ServiceManager.getService(Plugin.class);
+        this.plugin = ApplicationManager.getApplication().getService(Plugin.class);
     }
 
     public static ExceptionRenderer getInstance() {
-        return ServiceManager.getService(ExceptionRenderer.class);
+        return ApplicationManager.getApplication().getService(ExceptionRenderer.class);
     }
 
     public void render(@NotNull final GitLinkException exception) {

--- a/src/main/java/uk/co/ben_gibson/git/link/UI/Settings/ConfigurableSettings.java
+++ b/src/main/java/uk/co/ben_gibson/git/link/UI/Settings/ConfigurableSettings.java
@@ -1,6 +1,6 @@
 package uk.co.ben_gibson.git.link.UI.Settings;
 
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.project.Project;
@@ -26,8 +26,8 @@ public class ConfigurableSettings implements Configurable
     {
         ui = new uk.co.ben_gibson.git.link.UI.Settings.Settings(
             Preferences.getInstance(project),
-            ServiceManager.getService(UrlModifierProvider.class).modifiers(),
-            ServiceManager.getService(Plugin.class)
+            ApplicationManager.getApplication().getService(UrlModifierProvider.class).modifiers(),
+            ApplicationManager.getApplication().getService(Plugin.class)
         );
 
         return ui.getRootPanel();
@@ -43,13 +43,13 @@ public class ConfigurableSettings implements Configurable
 
     public String getHelpTopic()
     {
-        return ServiceManager.getService(Plugin.class).displayName();
+        return ApplicationManager.getApplication().getService(Plugin.class).displayName();
     }
 
 
     public String getDisplayName()
     {
-        return ServiceManager.getService(Plugin.class).displayName();
+        return ApplicationManager.getApplication().getService(Plugin.class).displayName();
     }
 
 

--- a/src/main/java/uk/co/ben_gibson/git/link/Url/Factory/UrlFactoryLocator.java
+++ b/src/main/java/uk/co/ben_gibson/git/link/Url/Factory/UrlFactoryLocator.java
@@ -1,6 +1,6 @@
 package uk.co.ben_gibson.git.link.Url.Factory;
 
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import uk.co.ben_gibson.git.link.Preferences;
 import uk.co.ben_gibson.git.link.Url.Factory.Exception.UrlFactoryException;
@@ -14,19 +14,19 @@ public class UrlFactoryLocator
     private Preferences preferences;
 
     public static UrlFactoryLocator getInstance(Project project) {
-        return ServiceManager.getService(project, UrlFactoryLocator.class);
+        return project.getService(UrlFactoryLocator.class);
     }
 
     public UrlFactoryLocator(Project project) {
 
         this.preferences = Preferences.getInstance(project);
 
-        this.factories.add(ServiceManager.getService(GitLabUrlFactory.class));
-        this.factories.add(ServiceManager.getService(GitHubUrlFactory.class));
-        this.factories.add(ServiceManager.getService(GogsUrlFactory.class));
-        this.factories.add(ServiceManager.getService(BitbucketServerUrlFactory.class));
-        this.factories.add(ServiceManager.getService(BitbucketCloudUrlFactory.class));
-        this.factories.add(ServiceManager.getService(project, CustomUrlFactory.class));
+        this.factories.add(ApplicationManager.getApplication().getService(GitLabUrlFactory.class));
+        this.factories.add(ApplicationManager.getApplication().getService(GitHubUrlFactory.class));
+        this.factories.add(ApplicationManager.getApplication().getService(GogsUrlFactory.class));
+        this.factories.add(ApplicationManager.getApplication().getService(BitbucketServerUrlFactory.class));
+        this.factories.add(ApplicationManager.getApplication().getService(BitbucketCloudUrlFactory.class));
+        this.factories.add(project.getService(CustomUrlFactory.class));
     }
 
     public UrlFactory locate() throws UrlFactoryException {

--- a/src/main/java/uk/co/ben_gibson/git/link/Url/Handler/BrowserHandler.java
+++ b/src/main/java/uk/co/ben_gibson/git/link/Url/Handler/BrowserHandler.java
@@ -1,7 +1,7 @@
 package uk.co.ben_gibson.git.link.Url.Handler;
 
 import com.intellij.ide.browsers.BrowserLauncher;
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.serviceContainer.NonInjectable;
 import org.jetbrains.annotations.NotNull;
 
@@ -21,7 +21,7 @@ public class BrowserHandler implements UrlHandler
     }
 
     public static BrowserHandler getInstance() {
-        return ServiceManager.getService(BrowserHandler.class);
+        return ApplicationManager.getApplication().getService(BrowserHandler.class);
     }
 
     @Override

--- a/src/main/java/uk/co/ben_gibson/git/link/Url/Handler/ClipboardHandler.java
+++ b/src/main/java/uk/co/ben_gibson/git/link/Url/Handler/ClipboardHandler.java
@@ -1,6 +1,6 @@
 package uk.co.ben_gibson.git.link.Url.Handler;
 
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.serviceContainer.NonInjectable;
 import org.jetbrains.annotations.NotNull;
 
@@ -22,7 +22,7 @@ public class ClipboardHandler implements UrlHandler
     }
 
     public static ClipboardHandler getInstance() {
-        return ServiceManager.getService(ClipboardHandler.class);
+        return ApplicationManager.getApplication().getService(ClipboardHandler.class);
     }
 
     @Override

--- a/src/main/java/uk/co/ben_gibson/git/link/Url/Substitution/URLTemplateProcessor.java
+++ b/src/main/java/uk/co/ben_gibson/git/link/Url/Substitution/URLTemplateProcessor.java
@@ -1,6 +1,6 @@
 package uk.co.ben_gibson.git.link.Url.Substitution;
 
-import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.application.ApplicationManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import uk.co.ben_gibson.git.link.Git.Branch;
@@ -23,7 +23,7 @@ import java.util.regex.Pattern;
 public class URLTemplateProcessor
 {
     public static URLTemplateProcessor getInstance() {
-        return ServiceManager.getService(URLTemplateProcessor.class);
+        return ApplicationManager.getApplication().getService(URLTemplateProcessor.class);
     }
 
     public URL process(


### PR DESCRIPTION
- [x] Resolve  ServiceManager.getService() deprecations.
- [x] Allow publishing for 2021.3 EAP.