### PR TITLE
Fix issue encoding hash character when used in a file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add images to README
 - Add Open Collective link to README
+- Fix issue where the '#' character in a file name is not correctly encoded.
 
 ## [4.0.1]
 - Fixed settings button opening the wrong menu.

--- a/src/main/kotlin/uk/co/ben_gibson/git/link/url/Encode.kt
+++ b/src/main/kotlin/uk/co/ben_gibson/git/link/url/Encode.kt
@@ -1,0 +1,5 @@
+package uk.co.ben_gibson.git.link.url
+
+import com.google.common.net.UrlEscapers
+
+fun encode(value: String): String = UrlEscapers.urlPathSegmentEscaper().escape(value)

--- a/src/main/kotlin/uk/co/ben_gibson/git/link/url/UrlExtensions.kt
+++ b/src/main/kotlin/uk/co/ben_gibson/git/link/url/UrlExtensions.kt
@@ -16,3 +16,21 @@ fun URL.toHttps(): URL {
 
     return URL("https", host, port, normalised)
 }
+
+fun URL.trimPath(): URL {
+    if (!path.endsWith("/")) {
+        return this;
+    }
+
+    var normalisedFile = path.trimEnd('/')
+
+    query?.let {
+        normalisedFile = normalisedFile.plus("?${query}")
+    }
+
+    ref?.let {
+        normalisedFile = normalisedFile.plus("#${ref}")
+    }
+
+    return URL(protocol, host, port, normalisedFile)
+}

--- a/src/test/kotlin/uk/co/ben_gibson/git/link/GitLabTest.kt
+++ b/src/test/kotlin/uk/co/ben_gibson/git/link/GitLabTest.kt
@@ -41,6 +41,15 @@ class GitLabTest {
                 "https://gitlab.com/my/repo/blob/b032a0707beac9a2f24b1b7d97ee4f7156de182c/src/Foo.java#L10-20"
             ),
             Arguments.of(
+                UrlOptionsFileAtBranch(
+                    REMOTE_BASE_URL,
+                    File("Code.cs", false, "Assets/#/Sources", false),
+                    BRANCH,
+                    LINE_SELECTION
+                ),
+                "https://gitlab.com/my/repo/blob/master/Assets/%23/Sources/Code.cs#L10-20"
+            ),
+            Arguments.of(
                 UrlOptionsFileAtCommit(
                     REMOTE_BASE_URL,
                     File("resources", true, "src/foo", false),


### PR DESCRIPTION
Using `URI(protocol, null, host, port, path, query, ref)` encodes the path correctly except for the `#` which is confusing. The fragment is sent in the `ref` argument, so it should know that it needs to be escaped. Switch to the encoder provided in `com.google.common.net` and encode the substitutions manually.
