### PR TITLE
Remove any scheme

### DIFF
--- a/src/main/kotlin/uk/co/ben_gibson/git/link/git/RemoteExtensions.kt
+++ b/src/main/kotlin/uk/co/ben_gibson/git/link/git/RemoteExtensions.kt
@@ -40,8 +40,7 @@ val GitRemote.httpUrl : URL? get() {
     if (!url.startsWith("http")) {
         url = url
             .replace("git@", "")
-            .replace("ssh://", "")
-            .replace("git://", "")
+            .replace(Regex("^[^:]+://"), "")
             .replace(":", "/")
 
         url = "http://".plus(url)

--- a/src/test/kotlin/uk/co/ben_gibson/git/link/git/RemoteTest.kt
+++ b/src/test/kotlin/uk/co/ben_gibson/git/link/git/RemoteTest.kt
@@ -42,6 +42,10 @@ class RemoteTest {
                 "http://custom.gitlab.url/group/project"
             ),
             Arguments.of(
+                "xy://custom.gitlab.url/group/project.git",
+                "http://custom.gitlab.url/group/project"
+            ),
+            Arguments.of(
                 "git@ssh.dev.azure.com:v3/ben-gibson/test/test",
                 "http://dev.azure.com/ben-gibson/test/test"
             ),


### PR DESCRIPTION
Thank you for working on this extension!

Instead of only removing `ssh://` or `git://`, remove any scheme.

In my setup I use a fake scheme that is then intercepted by a custom git remote transport helper for a self-hosted GitLab instance.

Without this change, the custom scheme e.g. `xy://` shows up in the resulting URL as `xy/`. See the issue below that this fixes.

The URL deduction is otherwise perfect.

Fixes https://github.com/ben-gibson/GitLink/issues/294