### PR TITLE
Retrieve full commit hash from Intellij VCS log

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ repositories {
 dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.9.0")
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
+    testImplementation("io.mockk:mockk:1.13.5")
     implementation(files("libs/url-0.0.10.jar"))
     implementation("org.jetbrains.kotlin:kotlin-reflect:1.6.10")
 

--- a/src/main/kotlin/uk/co/ben_gibson/git/link/ui/actions/vcslog/BrowserAction.kt
+++ b/src/main/kotlin/uk/co/ben_gibson/git/link/ui/actions/vcslog/BrowserAction.kt
@@ -14,7 +14,7 @@ class BrowserAction: Action(Type.BROWSER) {
 
         val vcsCommit = vcsLog.selectedDetails[0]
 
-        return ContextCommit(vcsCommit.root, Commit(vcsCommit.id.toShortString()))
+        return ContextCommit(vcsCommit.root, Commit(vcsCommit.id.asString()))
     }
 
     override fun shouldBeEnabled(event: AnActionEvent): Boolean {

--- a/src/main/kotlin/uk/co/ben_gibson/git/link/ui/actions/vcslog/CopyAction.kt
+++ b/src/main/kotlin/uk/co/ben_gibson/git/link/ui/actions/vcslog/CopyAction.kt
@@ -13,7 +13,7 @@ class CopyAction: Action(Type.COPY) {
         val vcsLog = event.getData(VcsLogDataKeys.VCS_LOG) ?: return null
         val vcsCommit = vcsLog.selectedDetails[0]
 
-        return ContextCommit(vcsCommit.root, Commit(vcsCommit.id.toShortString()))
+        return ContextCommit(vcsCommit.root, Commit(vcsCommit.id.toString()))
     }
 
     override fun shouldBeEnabled(event: AnActionEvent): Boolean {

--- a/src/main/kotlin/uk/co/ben_gibson/git/link/ui/actions/vcslog/MarkdownAction.kt
+++ b/src/main/kotlin/uk/co/ben_gibson/git/link/ui/actions/vcslog/MarkdownAction.kt
@@ -13,7 +13,7 @@ class MarkdownAction: Action(Type.COPY_MARKDOWN) {
         val vcsLog = event.getData(VcsLogDataKeys.VCS_LOG) ?: return null
         val vcsCommit = vcsLog.selectedDetails[0]
 
-        return ContextCommit(vcsCommit.root, Commit(vcsCommit.id.toShortString()))
+        return ContextCommit(vcsCommit.root, Commit(vcsCommit.id.toString()))
     }
 
     override fun shouldBeEnabled(event: AnActionEvent): Boolean {

--- a/src/test/kotlin/uk/co/ben_gibson/git/link/ui/actions/vcslog/BrowserActionTest.kt
+++ b/src/test/kotlin/uk/co/ben_gibson/git/link/ui/actions/vcslog/BrowserActionTest.kt
@@ -1,0 +1,64 @@
+package uk.co.ben_gibson.git.link.ui.actions.vcslog
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.vcs.log.Hash
+import com.intellij.vcs.log.VcsLog
+import com.intellij.vcs.log.VcsLogDataKeys
+import com.intellij.vcs.log.VcsUser
+import com.intellij.vcs.log.impl.HashImpl
+import com.intellij.vcs.log.impl.VcsFileStatusInfo
+import git4idea.GitCommit
+import git4idea.history.GitCommitRequirements
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import uk.co.ben_gibson.git.link.ContextCommit
+import uk.co.ben_gibson.git.link.ui.actions.Action
+
+class BrowserActionTest {
+    @ParameterizedTest(name = "{0} retrieves full commit hash from VCS log")
+    @ValueSource(classes = [BrowserAction::class, CopyAction::class, MarkdownAction::class])
+    fun `retrieves full commit hash from VCS log`(actionClassToTest: Class<Action>) {
+        val projectDummy = mockk<Project>()
+        val anActionEventMock = prepareActionEventWithSingleSelectedCommitInVcsLog(
+            commitHash = "b032a0707beac9a2f24b1b7d97ee4f7156de182c"
+        )
+        val sut = actionClassToTest.constructors[0].newInstance() as Action
+
+        val context = sut.buildContext(projectDummy, anActionEventMock)
+
+        assertNotNull(context)
+        assertInstanceOf(ContextCommit::class.java, context)
+        assertEquals("b032a0707beac9a2f24b1b7d97ee4f7156de182c", (context as ContextCommit).commit.toString())
+    }
+
+    private fun prepareActionEventWithSingleSelectedCommitInVcsLog(commitHash: String): AnActionEvent {
+        val authorDummy = mockk<VcsUser>()
+        val commit = GitCommit(
+            mockk<Project>(),
+            HashImpl.build(commitHash),
+            emptyList<Hash>(),
+            0,
+            mockk<VirtualFile>(),
+            "subject",
+            authorDummy,
+            "commit message",
+            authorDummy,
+            0,
+            emptyList<List<VcsFileStatusInfo>>(),
+            mockk<GitCommitRequirements>()
+        )
+
+        val vcsLog = mockk<VcsLog>()
+        every { vcsLog.selectedDetails } returns listOf(commit)
+
+        val anActionEvent = mockk<AnActionEvent>()
+        every { anActionEvent.getData(VcsLogDataKeys.VCS_LOG) } returns vcsLog
+
+        return anActionEvent
+    }
+}


### PR DESCRIPTION
Hi @ben-gibson 

This should fix #301
It turned out, the context did not have full commit hash at all