### PR TITLE
311 Azure. fixing the problem when plugin generates wrong urls 

### DIFF
--- a/src/main/kotlin/uk/co/ben_gibson/git/link/url/factory/AzureUrlFactory.kt
+++ b/src/main/kotlin/uk/co/ben_gibson/git/link/url/factory/AzureUrlFactory.kt
@@ -17,7 +17,9 @@ class AzureUrlFactory: UrlFactory {
 
         // Azure expects this to be in the path between the project and repo name. It's already included when cloning the project using HTTPS, but not when cloning the project using SSH.
         if (!basePathParts.contains("_git")) {
-            basePathParts.add(1, "_git")
+            // urls might have an option company component, if that's the case we need to insert _git in between company/project and repository parts
+            val indexToAddGit = if (basePathParts.size >= 3) 2 else 1
+            basePathParts.add(indexToAddGit, "_git")
         }
         
         val baseUrl = URL(scheme = Scheme.https(), host = host, path = Path(basePathParts.joinToString("/")))

--- a/src/test/kotlin/uk/co/ben_gibson/git/link/url/AzureTest.kt
+++ b/src/test/kotlin/uk/co/ben_gibson/git/link/url/AzureTest.kt
@@ -16,6 +16,8 @@ class AzureTest {
 
         private val REMOTE_BASE_URL_WITH_GIT = URL.fromString("https://dev.azure.com/ben-gibson/_git/test")
         private val REMOTE_BASE_URL_WITHOUT_GIT = URL.fromString("https://dev.azure.com/ben-gibson/test")
+        private val REMOTE_BASE_URL_WITH_COMPANY_AND_GIT = URL.fromString("https://dev.azure.com/company/project/_git/test")
+        private val REMOTE_BASE_URL_WITH_COMPANY_WITHOUT_GIT = URL.fromString("https://dev.azure.com/company/project/test")
         private const val BRANCH = "master"
         private val COMMIT = Commit("b032a0707beac9a2f24b1b7d97ee4f7156de182c")
         private val FILE = File("Foo.java", false, "src", false)
@@ -61,6 +63,14 @@ class AzureTest {
             Arguments.of(
                 UrlOptionsCommit(REMOTE_BASE_URL_WITHOUT_GIT, COMMIT),
                 "https://dev.azure.com/ben-gibson/_git/test/commit/b032a0707beac9a2f24b1b7d97ee4f7156de182c"
+            ),
+            Arguments.of(
+                UrlOptionsCommit(REMOTE_BASE_URL_WITH_COMPANY_AND_GIT, COMMIT),
+                "https://dev.azure.com/company/project/_git/test/commit/b032a0707beac9a2f24b1b7d97ee4f7156de182c"
+            ),
+            Arguments.of(
+                UrlOptionsCommit(REMOTE_BASE_URL_WITH_COMPANY_WITHOUT_GIT, COMMIT),
+                "https://dev.azure.com/company/project/_git/test/commit/b032a0707beac9a2f24b1b7d97ee4f7156de182c"
             )
         )
     }


### PR DESCRIPTION
reproduced for SSH based remotes having optional company name in the base url.

https://github.com/ben-gibson/GitLink/issues/311

@ben-gibson 