### PR TITLE
Fix a rendering issue with the CONTRIBUTING doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,4 +13,4 @@ Contributions are **welcome**.
 - **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
 
 - **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make 
-- multiple intermediate commits while developing, please [squash them] before submitting.
+  multiple intermediate commits while developing, please [squash them] before submitting.


### PR DESCRIPTION
The CONTRIBUTING doc currently has a bug that causes it to render incorrectly:

> <img width="887" height="120" alt="image" src="https://github.com/user-attachments/assets/1cb69236-ee10-4dd3-ab39-db72a5225dab" />
>
> _Current rendering_

----

This PR fixes the mid-sentence break causing an additional bullet point to render:

> <img width="885" height="106" alt="image" src="https://github.com/user-attachments/assets/32730892-b663-46f1-a1e5-efa99d8a6e20" />
>
> _Fixed rendering_
